### PR TITLE
feat!: [SFEQS-1457] Add @pagopa/handler-kit + support ReaderTaskEither

### DIFF
--- a/.changeset/khaki-hotels-punch.md
+++ b/.changeset/khaki-hotels-punch.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/handler-kit": major
+---
+
+Rewrite handler-kit to use Reader Monad

--- a/.changeset/warm-zebras-move.md
+++ b/.changeset/warm-zebras-move.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/handler-kit-azure-func": major
+---
+
+Add support for Azure Functions

--- a/packages/handler-kit-azure-func/.eslintrc.js
+++ b/packages/handler-kit-azure-func/.eslintrc.js
@@ -1,0 +1,13 @@
+require("@rushstack/eslint-patch/modern-module-resolution");
+
+module.exports = {
+  env: {
+    es2021: true,
+    node: true,
+  },
+  extends: ["@pagopa/eslint-config/recommended"],
+  ignorePatterns: ["*.yaml", "**/*.spec.ts"],
+  rules: {
+    "max-classes-per-file": "off",
+  },
+};

--- a/packages/handler-kit-azure-func/.prettierignore
+++ b/packages/handler-kit-azure-func/.prettierignore
@@ -1,0 +1,2 @@
+dist
+coverage

--- a/packages/handler-kit-azure-func/README.md
+++ b/packages/handler-kit-azure-func/README.md
@@ -1,0 +1,49 @@
+# @pagopa/handler-kit-azure-func
+
+`@pagopa/handler-kit` adapter for `Azure Functions`
+
+### How to use it
+
+```typescript
+import { httpAzureFunction } from "@pagopa/handler-kit-azure-func";
+
+// Given an Handler
+// (from the @pagopa/handler README example)
+
+const GetMovies = H.of((req: H.HttpRequest) =>
+  pipe(
+    req.body,
+    // perform a refinement with io-ts, and returns a ValidationError
+    // that represents a 422 HTTP response
+    H.parse(GetMoviesBody),
+    E.map(({ genre }) => genre),
+    RTE.fromEither,
+    RTE.chainTaskEither(getMoviesByGenre),
+    RTE.map((movies) => ({ items: movies })),
+    // wrap in a 200 HTTP response, with content-type JSON
+    RTE.map(H.successJson),
+    // convert Error instances to problem json (RFC 7808) objects
+    RTE.orElseW(flow(H.toProblemJson, H.problemJson))
+  )
+);
+
+// instead of wiring manually the dependencies
+
+/*
+GetMovies({
+  input: ...,
+  inputDecoder: ...,
+  logger: ...,
+  movies: ...
+})*/
+
+// just use "httpAzureFunction"
+
+const GetMoviesFunction = httpAzureFunction(GetMovies)({
+  movies,
+});
+
+// now GetMoviesFunction can be called by the Azure runtime
+```
+
+See the unit tests for other examples

--- a/packages/handler-kit-azure-func/package.json
+++ b/packages/handler-kit-azure-func/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@pagopa/handler-kit-azure-func",
+  "version": "0.9.0",
+  "homepage": "https://github.com/pagopa/io-std#readme",
+  "bugs": {
+    "url": "https://github.com/pagopa/io-std/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pagopa/io-std.git"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup-node",
+    "format": "prettier --write .",
+    "test": "vitest run",
+    "coverage": "vitest run --coverage",
+    "lint": "eslint \"src/**\"",
+    "lint:fix": "eslint --fix \"src/**\"",
+    "typecheck": "tsc"
+  },
+  "dependencies": {
+    "@pagopa/handler-kit": "^0.9.0",
+    "@pagopa/logger": "^1.0.0",
+    "fp-ts": "^2.13.1",
+    "io-ts": "^2.2.20"
+  },
+  "devDependencies": {
+    "@azure/functions": "^3.5.0",
+    "@pagopa/eslint-config": "^3.0.0",
+    "@rushstack/eslint-patch": "^1.2.0",
+    "@vitest/coverage-c8": "^0.29.2",
+    "eslint": "^8.36.0",
+    "prettier": "2.8.4",
+    "tsup": "^6.6.3",
+    "typescript": "^5.0.2",
+    "vitest": "^0.29.2"
+  }
+}

--- a/packages/handler-kit-azure-func/src/__test__/function.spec.ts
+++ b/packages/handler-kit-azure-func/src/__test__/function.spec.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from "vitest";
+
+import * as t from "io-ts";
+
+import { Context, Form, AzureFunction } from "@azure/functions";
+
+import * as O from "fp-ts/Option";
+import * as E from "fp-ts/Either";
+import * as RTE from "fp-ts/ReaderTaskEither";
+
+import { pipe, flow } from "fp-ts/function";
+import { lookup } from "fp-ts/Record";
+
+import * as H from "@pagopa/handler-kit";
+
+import { azureFunction, httpAzureFunction } from "../function";
+
+function logger() {}
+logger.error = vi.fn(() => {});
+logger.warn = () => {};
+logger.info = () => {};
+logger.verbose = () => {};
+
+const baseCtx: Context = {
+  invocationId: "my-id",
+  executionContext: {
+    invocationId: "my-id",
+    functionName: "Greet",
+    functionDirectory: "./my-dir",
+    retryContext: null,
+  },
+  bindings: {},
+  bindingData: {
+    invocationId: "my-id",
+  },
+  traceContext: {
+    traceparent: null,
+    tracestate: null,
+    attributes: null,
+  },
+  bindingDefinitions: [],
+  log: logger,
+  done() {},
+};
+
+const invoke =
+  <P>(trigger: "httpTrigger" | "queueTrigger", name: string, payload: P) =>
+  (func: AzureFunction) =>
+    func({
+      ...baseCtx,
+      bindingDefinitions: [
+        ...baseCtx.bindingDefinitions,
+        {
+          type: trigger,
+          direction: "in",
+          name,
+        },
+      ],
+      bindings: {
+        ...baseCtx.bindings,
+        [name]: payload,
+      },
+    });
+
+const invokeFromHttpRequest = (req: {
+  method?: "GET" | "POST";
+  url?: string;
+  query?: Record<string, string>;
+  params?: Record<string, string>;
+  headers?: Record<string, string>;
+  body?: unknown;
+}) =>
+  invoke("httpTrigger", "req", {
+    user: null,
+    get: () => undefined,
+    parseFormBody: () => ({} as Form),
+    body: undefined,
+    headers: {},
+    params: {},
+    query: {},
+    url: "https://my-test.url.com/api",
+    method: "GET",
+    ...req,
+  });
+
+const HttpResponseC = t.partial({
+  statusCode: t.union([t.number, t.string]),
+  body: t.any,
+  headers: t.record(t.string, t.string),
+});
+
+describe("httpAzureFunction", () => {
+  const GreetHandler = H.of((req: H.HttpRequest) =>
+    pipe(
+      req.query,
+      lookup("name"),
+      O.getOrElse(() => "Test"),
+      RTE.right,
+      RTE.chainW((name) =>
+        RTE.asks<{ lang: "it" | "en" }, string>((r) =>
+          r.lang === "it" ? `Ciao ${name}` : `Hello ${name}`
+        )
+      ),
+      RTE.map((message) => ({ message })),
+      RTE.map(H.successJson),
+      RTE.orElseW(flow(H.toProblemJson, H.problemJson, RTE.right))
+    )
+  );
+  it("wires the http request correctly", async () => {
+    const GreetFunction = httpAzureFunction(GreetHandler)({
+      lang: "it",
+    });
+    await expect(
+      pipe(
+        GreetFunction,
+        invokeFromHttpRequest({
+          query: {
+            name: "luca",
+          },
+        })
+      )
+    ).resolves.toEqual(
+      expect.objectContaining({
+        body: {
+          message: "Ciao luca",
+        },
+      })
+    );
+  });
+  it("returns an Azure Http Response", async () => {
+    const GreetFunction = httpAzureFunction(GreetHandler)({
+      lang: "en",
+    });
+    const response = await pipe(GreetFunction, invokeFromHttpRequest({}));
+    expect(pipe(response, H.parse(HttpResponseC), E.isRight)).toBe(true);
+  });
+  it("recovers from uncaught errors", async () => {
+    const ErrorFunction = httpAzureFunction(
+      H.of((_) => RTE.left(new Error("unhandled error")))
+    )({});
+    const response = await pipe(ErrorFunction, invokeFromHttpRequest({}));
+    expect(logger.error).toHaveBeenCalled();
+    expect(pipe(response, H.parse(HttpResponseC))).toEqual(
+      expect.objectContaining({
+        right: expect.objectContaining({
+          statusCode: 500,
+        }),
+      })
+    );
+  });
+});
+
+describe("azureFunction", () => {
+  it("returns the same value of the handler", async () => {
+    const EchoFunc = azureFunction(H.of((str: string) => RTE.right(str)))({
+      inputDecoder: t.string,
+    });
+    const response = pipe(EchoFunc, invoke("queueTrigger", "str", "ping"));
+    await expect(response).resolves.toBe("ping");
+  });
+});

--- a/packages/handler-kit-azure-func/src/__test__/trigger.spec.ts
+++ b/packages/handler-kit-azure-func/src/__test__/trigger.spec.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Context } from "@azure/functions";
+
+import { getTriggerBindingData } from "../trigger";
+
+function logger() {}
+logger.error = vi.fn(() => {});
+logger.warn = () => {};
+logger.info = () => {};
+logger.verbose = () => {};
+
+const baseCtx: Context = {
+  invocationId: "my-id",
+  executionContext: {
+    invocationId: "my-id",
+    functionName: "Greet",
+    functionDirectory: "./my-dir",
+    retryContext: null,
+  },
+  bindings: {},
+  bindingData: {
+    invocationId: "my-id",
+  },
+  traceContext: {
+    traceparent: null,
+    tracestate: null,
+    attributes: null,
+  },
+  bindingDefinitions: [],
+  log: logger,
+  done() {},
+};
+
+describe("getTriggerBindingData", () => {
+  it("returns the payload of the defined trigger binding", () => {
+    const payload = "TEST!";
+    const ctx: Context = {
+      ...baseCtx,
+      bindingDefinitions: [
+        {
+          type: "queueTrigger",
+          direction: "in",
+          name: "foo",
+        },
+      ],
+      bindings: {
+        foo: payload,
+      },
+    };
+    const data = getTriggerBindingData()(ctx);
+    expect(data).toEqual(
+      expect.objectContaining({
+        right: payload,
+      })
+    );
+  });
+});

--- a/packages/handler-kit-azure-func/src/function.ts
+++ b/packages/handler-kit-azure-func/src/function.ts
@@ -1,0 +1,120 @@
+import * as azure from "@azure/functions";
+
+import * as t from "io-ts";
+
+import * as T from "fp-ts/Task";
+import * as RE from "fp-ts/ReaderEither";
+import * as TE from "fp-ts/TaskEither";
+
+import { sequenceS } from "fp-ts/Apply";
+import { pipe, flow } from "fp-ts/function";
+
+import * as H from "@pagopa/handler-kit";
+import * as L from "@pagopa/logger";
+
+import { getLogger } from "./logger";
+import { getTriggerBindingData } from "./trigger";
+
+const hasLogger = <R, I>(
+  u: unknown
+): u is R & { logger: L.Logger } & H.HandlerEnvironment<I> =>
+  typeof u === "object" && u !== null && "logger" in u;
+
+const azureFunctionTE = <I, A, R>(
+  h: H.Handler<I, A, R>,
+  deps: Omit<R, "logger"> & { inputDecoder: t.Decoder<unknown, I> }
+) =>
+  flow(
+    sequenceS(RE.Apply)({
+      logger: RE.fromReader(getLogger),
+      input: getTriggerBindingData(),
+    }),
+    TE.fromEither,
+    TE.map(({ input, logger }) => ({ input, logger, ...deps })),
+    TE.filterOrElse(hasLogger<R, I>, () => new Error("Unmeet dependencies")),
+    TE.chainW(h)
+  );
+
+export const azureFunction =
+  <I, A, R>(h: H.Handler<I, A, R>) =>
+  (
+    deps: Omit<R, "logger"> & { inputDecoder: t.Decoder<unknown, I> }
+  ): azure.AzureFunction =>
+  (ctx) =>
+    pipe(ctx, azureFunctionTE(h, deps), TE.toUnion)();
+
+const HttpRequestC = new t.Type<
+  H.HttpRequest,
+  AzureHttpRequest,
+  AzureHttpRequest
+>(
+  "NumberCodec",
+  H.HttpRequest.is,
+  ({ params: path, ...req }) =>
+    t.success({
+      ...req,
+      path,
+    }),
+  /* c8 ignore next 4 */
+  ({ path: params, ...req }) => ({
+    ...req,
+    params,
+  })
+);
+
+const AzureHttpRequestC = t.type({
+  method: H.HttpRequest.props.method,
+  url: t.string,
+  params: t.record(t.string, t.string),
+  query: t.record(t.string, t.string),
+  headers: t.record(t.string, t.string),
+  body: t.unknown,
+});
+
+type AzureHttpRequest = t.TypeOf<typeof AzureHttpRequestC>;
+
+const HttpRequestFromAzure = AzureHttpRequestC.pipe(
+  HttpRequestC,
+  "HttpRequestFromAzure"
+);
+
+const toAzureHttpResponse = (
+  res: H.HttpResponse<unknown, H.HttpStatusCode>
+): azure.HttpResponse => ({
+  statusCode: res.statusCode,
+  body: res.body,
+  headers: res.headers,
+});
+
+const logErrorAndReturnHttpResponse = (e: Error) =>
+  flow(
+    L.error("uncaught error from handler", { error: e }),
+    T.fromIO,
+    T.map(() =>
+      pipe(
+        new H.HttpError("Something went wrong."),
+        H.toProblemJson,
+        H.problemJson
+      )
+    )
+  );
+
+export const httpAzureFunction =
+  <R>(
+    h: H.Handler<H.HttpRequest, H.HttpResponse<unknown, H.HttpStatusCode>, R>
+  ) =>
+  (deps: Omit<R, "logger">): azure.AzureFunction =>
+  (ctx) =>
+    pipe(
+      ctx,
+      azureFunctionTE(h, {
+        ...deps,
+        inputDecoder: HttpRequestFromAzure,
+      }),
+      TE.getOrElseW((e) =>
+        logErrorAndReturnHttpResponse(e)({
+          logger: getLogger(ctx),
+        })
+      ),
+      T.map(toAzureHttpResponse)
+    )();

--- a/packages/handler-kit-azure-func/src/index.ts
+++ b/packages/handler-kit-azure-func/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./function";

--- a/packages/handler-kit-azure-func/src/logger.ts
+++ b/packages/handler-kit-azure-func/src/logger.ts
@@ -2,6 +2,7 @@ import * as azure from "@azure/functions";
 
 import * as L from "@pagopa/logger";
 
+// Derive a concrete implementation L.Logger using azure.Context.log
 export const getLogger = (ctx: azure.Context): L.Logger => ({
   log: (s, level) => () => {
     const logFunc: Record<typeof level, (s: string) => void> = {

--- a/packages/handler-kit-azure-func/src/logger.ts
+++ b/packages/handler-kit-azure-func/src/logger.ts
@@ -1,0 +1,22 @@
+import * as azure from "@azure/functions";
+
+import * as L from "@pagopa/logger";
+
+export const getLogger = (ctx: azure.Context): L.Logger => ({
+  log: (s, level) => () => {
+    const logFunc: Record<typeof level, (s: string) => void> = {
+      debug: ctx.log.verbose,
+      info: ctx.log.info,
+      warn: ctx.log.warn,
+      error: ctx.log.error,
+      fatal: ctx.log.error,
+    };
+    logFunc[level](s);
+  },
+  format:
+    process.env.NODE_ENV === "development" ? L.format.simple : L.format.json,
+  context: {
+    invocationId: ctx.invocationId,
+    functionName: ctx.executionContext.functionName,
+  },
+});

--- a/packages/handler-kit-azure-func/src/trigger.ts
+++ b/packages/handler-kit-azure-func/src/trigger.ts
@@ -1,0 +1,55 @@
+import * as t from "io-ts";
+
+import { flow, pipe } from "fp-ts/function";
+
+import { lookup } from "fp-ts/Record";
+
+import * as A from "fp-ts/Array";
+
+import * as azure from "@azure/functions";
+
+import * as E from "fp-ts/Either";
+
+import * as RE from "fp-ts/ReaderEither";
+
+const FunctionTrigger = t.type({
+  type: t.keyof({
+    httpTrigger: null,
+    queueTrigger: null,
+    blobTrigger: null,
+    eventHubTrigger: null,
+  }),
+  direction: t.literal("in"),
+  name: t.string,
+});
+
+const getFunctionTrigger = () =>
+  flow(
+    (ctx: azure.Context) => ctx.bindingDefinitions,
+    A.findLast(FunctionTrigger.is),
+    E.fromOption(() => new Error("Trigger not supported."))
+  );
+
+export class BindingNotFoundError extends Error {
+  name = "BindingNotFoundError";
+  bindingName: string;
+  bindings: azure.ContextBindingData;
+  constructor(bindingName: string, bindings: azure.ContextBindingData) {
+    super("Unable to find binding data");
+    this.bindingName = bindingName;
+    this.bindings = bindings;
+  }
+}
+
+const getBindingData = (name: string) => (ctx: azure.Context) =>
+  pipe(
+    ctx.bindings,
+    lookup(name),
+    E.fromOption((): Error => new BindingNotFoundError(name, ctx.bindingData))
+  );
+
+export const getTriggerBindingData = flow(
+  getFunctionTrigger,
+  RE.map((trigger) => trigger.name),
+  RE.chain(getBindingData)
+);

--- a/packages/handler-kit-azure-func/tsconfig.json
+++ b/packages/handler-kit-azure-func/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  }
+}

--- a/packages/handler-kit-azure-func/tsup.config.js
+++ b/packages/handler-kit-azure-func/tsup.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["./src/index.ts"],
+  splitting: false,
+  sourcemap: true,
+  dts: true,
+  clean: true,
+  target: "node18",
+});

--- a/packages/handler-kit/.eslintrc.js
+++ b/packages/handler-kit/.eslintrc.js
@@ -1,0 +1,13 @@
+require("@rushstack/eslint-patch/modern-module-resolution");
+
+module.exports = {
+  env: {
+    es2021: true,
+    node: true,
+  },
+  extends: ["@pagopa/eslint-config/recommended"],
+  ignorePatterns: ["*.yaml", "**/*.spec.ts"],
+  rules: {
+    "max-classes-per-file": "off",
+  },
+};

--- a/packages/handler-kit/.prettierignore
+++ b/packages/handler-kit/.prettierignore
@@ -1,0 +1,2 @@
+dist
+coverage

--- a/packages/handler-kit/README.md
+++ b/packages/handler-kit/README.md
@@ -1,0 +1,100 @@
+# @pagopa/handler-kit
+
+A minimal toolkit to make `handlers` in TypeScript & `fp-ts`
+
+## What is an Handler?
+
+An `Handler` is a specialization of fp-ts' `ReaderTaskEither` that takes a value as `input` and ensures uniform error handling and validation.
+
+It is particularly useful for creating HTTP-agnostic "controllers" that can be adapted to any framework.
+
+This package contains useful functions for creating handlers, manipulating them, abstracting HTTP controllers, and uniformly handling errors
+
+## How to use it
+
+```typescript
+import * as H from "@pagopa/handler-kit";
+import * as L from "@pagopa/logger";
+
+import * as E from "fp-ts/Either";
+import * as RTE from "fp-ts/ReaderTaskEither";
+import * as TE from "fp-ts/TaskEither";
+import { pipe, flow } from "fp-ts/function";
+import { lookup } from "fp-ts/Record";
+
+import * as t from "io-ts";
+
+const GetMoviesBody = t.type({
+  genre: t.keyof({
+    action: null,
+    comedy: null,
+    drama: null,
+    horror: null,
+    "sci-fi": null,
+  }),
+});
+
+type GetMoviesBody = t.TypeOf<typeof GetMoviesBody>;
+
+const movies = {
+  action: ["die hard"],
+  horror: ["shining", "the exorcist"],
+};
+
+const getMoviesByGenre =
+  (genre: GetMoviesBody["genre"]) =>
+  (r: { movies: Record<string, string[]> }) =>
+    pipe(
+      r.movies,
+      lookup(genre),
+      TE.fromOption(
+        () => new H.HttpNotFoundError("there are no movies for this genre")
+      )
+    );
+
+// Reads genre from HTTP body,
+// then performs an effecful search
+// and returns an HTTP response.
+const GetMovies = H.of((req: H.HttpRequest) =>
+  pipe(
+    req.body,
+    // perform a refinement with io-ts, and returns a ValidationError
+    // that represents a 422 HTTP response
+    H.parse(GetMoviesBody),
+    E.map(({ genre }) => genre),
+    RTE.fromEither,
+    RTE.chainTaskEither(getMoviesByGenre),
+    RTE.map((movies) => ({ items: movies })),
+    // wrap in a 200 HTTP response, with content-type JSON
+    RTE.map(H.successJson),
+    // converts Error instances to problem json (RFC 7808) objects
+    RTE.orElseW(flow(H.toProblemJson, H.problemJson))
+  )
+);
+
+// Run the handler
+// too boilerplate? :P don't panic, see the handler-kit adapters
+
+const httpRequest = {
+  method: "POST",
+  body: {
+    genre: "sci-fi",
+  },
+  url: "https://my-req.url/",
+  query: {},
+  headers: {},
+  path: {},
+};
+
+GetMovies({
+  input: httpRequest,
+  inputDecoder: H.HttpRequest,
+  logger: {
+    log: (r) => () => console.log(r),
+    format: L.format.simple,
+  },
+  movies,
+})();
+```
+
+See the unit tests for other examples

--- a/packages/handler-kit/package.json
+++ b/packages/handler-kit/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@pagopa/handler-kit",
+  "version": "0.9.0",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "scripts": {
+    "build": "tsup-node",
+    "format": "prettier --write .",
+    "test": "vitest run",
+    "coverage": "vitest run --coverage",
+    "lint": "eslint \"src/**\"",
+    "lint:fix": "eslint --fix \"src/**\"",
+    "typecheck": "tsc"
+  },
+  "dependencies": {
+    "@pagopa/logger": "^1.0.0",
+    "fp-ts": "^2.13.1",
+    "io-ts": "^2.2.20",
+    "tsup": "^6.6.3"
+  },
+  "devDependencies": {
+    "@pagopa/eslint-config": "^3.0.0",
+    "@rushstack/eslint-patch": "^1.2.0",
+    "@vitest/coverage-c8": "^0.29.2",
+    "eslint": "^8.36.0",
+    "prettier": "2.8.4",
+    "typescript": "^5.0.2",
+    "vitest": "^0.29.2"
+  }
+}

--- a/packages/handler-kit/src/__test__/handler.spec.ts
+++ b/packages/handler-kit/src/__test__/handler.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi } from "vitest";
+
+import * as RTE from "fp-ts/ReaderTaskEither";
+import * as t from "io-ts";
+
+import * as H from "../handler";
+
+import * as E from "fp-ts/Either";
+
+import { ValidationError } from "../validation";
+import * as L from "@pagopa/logger";
+
+const logger: L.Logger = {
+  log: () => () => {},
+  format: () => "",
+};
+
+describe("handler", () => {
+  describe("of", () => {
+    it('Should call the decode function of the "itemDecoder" provided', async () => {
+      const inputDecoder: t.Decoder<unknown, 1> = {
+        name: "inputDecoder",
+        decode: vi.fn(() => t.success(1)),
+        validate: () => t.success(1),
+      };
+      const GimmeOne = H.of((item: 1) => RTE.right(item));
+      const run = GimmeOne({
+        input: 2,
+        inputDecoder,
+        logger,
+      });
+      await run();
+      expect(inputDecoder.decode).toHaveBeenCalledOnce();
+      expect(inputDecoder.decode).toHaveBeenCalledWith(2);
+    });
+    it("Should return a ValidationError when the provided item didn't validate", async () => {
+      const GreetHandler = H.of((name: string) => RTE.right(`Hello, ${name}`));
+      const run = GreetHandler({
+        input: 10,
+        inputDecoder: t.string,
+        logger,
+      });
+      const result = await run();
+      expect.assertions(2);
+      expect(E.isLeft(result)).toBe(true);
+      if (E.isLeft(result)) {
+        expect(result.left).toBeInstanceOf(ValidationError);
+      }
+    });
+  });
+});

--- a/packages/handler-kit/src/__test__/validation.spec.ts
+++ b/packages/handler-kit/src/__test__/validation.spec.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from "vitest";
+
+import * as t from "io-ts";
+
+import { ValidationError, parse } from "../validation";
+
+describe("validation", () => {
+  describe("ValidationError", () => {
+    it('should have "ValidationError" as name', () => {
+      const e = new ValidationError([]);
+      expect(e.name).toBe("ValidationError");
+    });
+  });
+  describe("parse", () => {
+    it("calls the decode method of the provided schema", () => {
+      const payload = { message: "this is a test " };
+      const payloadC = t.type({ message: t.string });
+      payloadC.decode = vi.fn(() => t.success(payload));
+      parse(payloadC)(payload);
+      expect(payloadC.decode).toHaveBeenCalled();
+      expect(payloadC.decode).toHaveBeenCalledWith(payload);
+    });
+    it.todo("returns a ValidationError on error", () => {});
+    it.todo("correctly refines a type", () => {});
+  });
+});

--- a/packages/handler-kit/src/handler.ts
+++ b/packages/handler-kit/src/handler.ts
@@ -1,0 +1,32 @@
+import { pipe } from "fp-ts/function";
+import * as RTE from "fp-ts/ReaderTaskEither";
+
+import * as L from "@pagopa/logger";
+
+import { Decoder } from "io-ts";
+
+import { parse } from "./validation";
+
+export type HandlerEnvironment<I> = {
+  input: unknown;
+  inputDecoder: Decoder<unknown, I>;
+  logger: L.Logger;
+};
+
+export type Handler<I, A, R = object> = RTE.ReaderTaskEither<
+  R & HandlerEnvironment<I>,
+  Error,
+  A
+>;
+
+export const of = <I, A, R = object>(
+  endpoint: (input: I) => RTE.ReaderTaskEither<R, Error, A>
+): Handler<I, A, R> =>
+  pipe(
+    RTE.ask<HandlerEnvironment<I>>(),
+    RTE.chainEitherKW(({ input, inputDecoder }) =>
+      pipe(input, parse(inputDecoder))
+    ),
+    RTE.chainFirstW((input) => L.debugRTE("input decoded", { input })),
+    RTE.chainW(endpoint)
+  );

--- a/packages/handler-kit/src/http/__test__/error.spec.ts
+++ b/packages/handler-kit/src/http/__test__/error.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, test, expect } from "vitest";
+import { ValidationError } from "../../validation";
+
+import {
+  HttpError,
+  HttpBadRequestError,
+  HttpUnauthorizedError,
+  HttpForbiddenError,
+  HttpNotFoundError,
+  HttpConflictError,
+  HttpUnprocessableEntityError,
+  HttpTooManyRequestsError,
+  HttpServiceUnavailableError,
+  toProblemJson,
+} from "../error";
+
+import { HttpErrorStatusCode } from "../response";
+
+describe("error", () => {
+  describe("toProblemJson", () => {
+    it("maps to a ProblemJson with an undefined type on HttpError", () => {
+      const e = new HttpError("There was an error!");
+      const problem = toProblemJson(e);
+      expect(problem).not.toHaveProperty("type");
+    });
+    it('maps to a ProblemJson with a "/problem/validation-error" type on ValidationError', () => {
+      const e = new ValidationError(["this is just an example of a violation"]);
+      const problem = toProblemJson(e);
+      expect(problem).toHaveProperty("type", "/problem/validation-error");
+      expect(problem).toHaveProperty("status", 422);
+    });
+    it("maps to a ProblemJson with status 500 on not handled errors", () => {
+      const e = new Error("something went wrong!");
+      const problem = toProblemJson(e);
+      expect(problem).toHaveProperty("status", 500);
+    });
+  });
+  describe("HttpError", () => {
+    test("each HttpError variant should have its own right HTTP status code", () => {
+      const testTable: Array<[HttpError, HttpErrorStatusCode]> = [
+        [new HttpError(), 500],
+        [new HttpBadRequestError(), 400],
+        [new HttpUnauthorizedError(), 401],
+        [new HttpForbiddenError(), 403],
+        [new HttpNotFoundError(), 404],
+        [new HttpConflictError(), 409],
+        [new HttpUnprocessableEntityError(), 422],
+        [new HttpTooManyRequestsError(), 429],
+        [new HttpServiceUnavailableError(), 503],
+      ];
+      testTable.forEach(([e, statusCode]) => {
+        expect(e.status).toBe(statusCode);
+      });
+    });
+  });
+});

--- a/packages/handler-kit/src/http/__test__/response.spec.ts
+++ b/packages/handler-kit/src/http/__test__/response.spec.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  empty,
+  HttpResponse,
+  HttpErrorStatusCode,
+  success,
+  successJson,
+  problemJson,
+  withHeader,
+  withStatusCode,
+  withSecurityHeaders,
+  ProblemJson,
+} from "../response";
+
+import { pipe } from "fp-ts/function";
+import { lookup } from "fp-ts/Record";
+import * as O from "fp-ts/Option";
+
+describe("response", () => {
+  describe("withStatusCode", () => {
+    it("should return a new response with the updated status code", () => {
+      const updated = pipe(empty, withStatusCode(404));
+      expect(empty.statusCode).toBe(204);
+      expect(updated.statusCode).toBe(404);
+    });
+    describe("withHeader", () => {
+      it("should return a new response with the updated header", () => {
+        const updated = pipe(empty, withHeader("x-io-test-type", "unit"));
+        const hasHeaderWithValue =
+          (name: string, expectedValue: string) =>
+          (res: HttpResponse<null, 204>) =>
+            pipe(
+              res.headers,
+              lookup(name),
+              O.filter((value) => value === expectedValue),
+              O.isSome
+            );
+        const hasXIOTestHeader = hasHeaderWithValue("x-io-test-type", "unit");
+        expect(hasXIOTestHeader(empty)).toBe(false);
+        expect(hasXIOTestHeader(updated)).toBe(true);
+      });
+    });
+  });
+  describe("empty", () => {
+    it("should have 204 as status code", () => {
+      expect(empty.statusCode).toBe(204);
+    });
+    it("should have a null body", () => {
+      expect(empty.body).toBeNull();
+    });
+    it("should include security headers", () => {
+      const responseWithSecHeaders: HttpResponse<null, 204> =
+        withSecurityHeaders({ statusCode: 204, body: null, headers: {} });
+      expect(empty.headers).toMatchObject(responseWithSecHeaders.headers);
+    });
+  });
+  describe("success", () => {
+    it("should create an HttpResponse with status 200", () => {
+      const response = success({ message: "it works!" });
+      expect(response.statusCode).toBe(200);
+    });
+    it("should create an HttpResponse with security headers", () => {
+      const response = success({ message: "it works!" });
+      const responseWithSecHeaders: HttpResponse<null, 204> =
+        withSecurityHeaders({ statusCode: 204, body: null, headers: {} });
+      expect(response.headers).toMatchObject(responseWithSecHeaders.headers);
+    });
+  });
+  describe("successJson", () => {
+    it("should create an HttpResponse with status 200", () => {
+      const response = successJson({ message: "it works!" });
+      expect(response.statusCode).toBe(200);
+    });
+    it("should create an HttpResponse with Content-Type header valued as application/json", () => {
+      const response = successJson({
+        message: "it works!! but check the headers ",
+      });
+      expect(response.headers).toHaveProperty(
+        "Content-Type",
+        "application/json"
+      );
+    });
+  });
+  describe("problemJson", () => {
+    it("should create an HttpResponse with Content-Type header valued as application/problem+json", () => {
+      const problem: ProblemJson = { status: 400, title: "Test problem." };
+      const response = problemJson(problem);
+      expect(response.headers).toHaveProperty(
+        "Content-Type",
+        "application/problem+json"
+      );
+    });
+    it("should create an HttpResponse with the appropriate status code", () => {
+      const statuses: Array<HttpErrorStatusCode> = [404, 401, 500];
+      statuses.forEach((status) => {
+        expect(problemJson({ title: "Test problem.", status })).toHaveProperty(
+          "statusCode",
+          status
+        );
+      });
+    });
+  });
+});

--- a/packages/handler-kit/src/http/error.ts
+++ b/packages/handler-kit/src/http/error.ts
@@ -62,6 +62,7 @@ export const toProblemJson = (e: Error): ProblemJson => {
     return {
       title: e.title,
       status: e.status,
+      detail: e.message,
     };
   }
   return {

--- a/packages/handler-kit/src/http/error.ts
+++ b/packages/handler-kit/src/http/error.ts
@@ -1,0 +1,72 @@
+import { ValidationError } from "../validation";
+import { HttpErrorStatusCode, ProblemJson } from "./response";
+
+export class HttpError extends Error {
+  name = "HttpError";
+  status: HttpErrorStatusCode = 500 as const;
+  title = "Internal Server Error";
+}
+
+export class HttpBadRequestError extends HttpError {
+  status = 400 as const;
+  title = "Bad Request";
+}
+
+export class HttpUnauthorizedError extends HttpError {
+  status = 401 as const;
+  title = "Unauthorized";
+  message = "You must provide a valid API key to access this resource.";
+}
+
+export class HttpForbiddenError extends HttpError {
+  status = 403 as const;
+  title = "Forbidden";
+}
+
+export class HttpNotFoundError extends HttpError {
+  status = 404 as const;
+  title = "Not Found";
+}
+
+export class HttpConflictError extends HttpError {
+  status = 409 as const;
+  title = "Conflict";
+}
+
+export class HttpUnprocessableEntityError extends HttpError {
+  status = 422 as const;
+  title = "Unprocessable Entity";
+}
+
+export class HttpTooManyRequestsError extends HttpError {
+  status = 429 as const;
+  title = "Too many request";
+}
+
+export class HttpServiceUnavailableError extends HttpError {
+  status = 503 as const;
+  title = "Service Unavailable";
+}
+
+export const toProblemJson = (e: Error): ProblemJson => {
+  if (e instanceof ValidationError) {
+    return {
+      type: "/problem/validation-error",
+      title: "Validation Error",
+      detail: "Your request didn't validate",
+      status: 422,
+      violations: e.violations,
+    };
+  }
+  if (e instanceof HttpError) {
+    return {
+      title: e.title,
+      status: e.status,
+    };
+  }
+  return {
+    title: "Internal Server Error",
+    detail: "Something went wrong",
+    status: 500,
+  };
+};

--- a/packages/handler-kit/src/http/index.ts
+++ b/packages/handler-kit/src/http/index.ts
@@ -1,0 +1,3 @@
+export * from "./error";
+export * from "./request";
+export * from "./response";

--- a/packages/handler-kit/src/http/request.ts
+++ b/packages/handler-kit/src/http/request.ts
@@ -1,0 +1,31 @@
+import * as t from "io-ts";
+
+export const HttpRequest = t.type({
+  method: t.keyof({
+    GET: null,
+    POST: null,
+    PUT: null,
+    PATCH: null,
+    DELETE: null,
+    HEAD: null,
+    OPTIONS: null,
+    TRACE: null,
+    CONNECT: null,
+  }),
+  path: t.record(t.string, t.string),
+  query: t.record(t.string, t.string),
+  headers: t.record(t.string, t.string),
+  body: t.unknown,
+  url: t.string,
+});
+
+export type HttpRequest = t.TypeOf<typeof HttpRequest>;
+
+export const request = (url: string): HttpRequest => ({
+  url,
+  method: "GET",
+  path: {},
+  query: {},
+  headers: {},
+  body: undefined,
+});

--- a/packages/handler-kit/src/http/response.ts
+++ b/packages/handler-kit/src/http/response.ts
@@ -1,0 +1,130 @@
+import { flow } from "fp-ts/function";
+import * as t from "io-ts";
+
+const HttpSuccessStatusCode = t.union([
+  t.literal(200),
+  t.literal(201),
+  t.literal(202),
+  t.literal(204),
+]);
+
+export type HttpSuccessStatusCode = t.TypeOf<typeof HttpSuccessStatusCode>;
+
+const HttpRedirectionStatusCode = t.union([
+  t.literal(301),
+  t.literal(302),
+  t.literal(304),
+]);
+
+const HttpErrorStatusCode = t.union([
+  t.literal(400),
+  t.literal(401),
+  t.literal(403),
+  t.literal(404),
+  t.literal(409),
+  t.literal(422),
+  t.literal(429),
+  t.literal(500),
+  t.literal(501),
+  t.literal(503),
+]);
+
+export type HttpErrorStatusCode = t.TypeOf<typeof HttpErrorStatusCode>;
+
+const HttpStatusCode = t.union([
+  HttpSuccessStatusCode,
+  HttpRedirectionStatusCode,
+  HttpErrorStatusCode,
+]);
+
+export type HttpStatusCode = t.TypeOf<typeof HttpStatusCode>;
+
+export type HttpResponse<A, S extends HttpStatusCode = 200> = {
+  statusCode: S;
+  headers: Record<string, string>;
+  body: A;
+};
+
+export const withStatusCode =
+  <S extends HttpStatusCode>(statusCode: S) =>
+  <A>(r: HttpResponse<A, HttpStatusCode>): HttpResponse<A, S> => ({
+    ...r,
+    statusCode,
+  });
+
+export const withHeader =
+  (name: string, value: string) =>
+  <A, S extends HttpStatusCode>({
+    headers,
+    ...r
+  }: HttpResponse<A, S>): HttpResponse<A, S> => ({
+    ...r,
+    headers: {
+      ...headers,
+      [name]: value,
+    },
+  });
+
+// Adds security headers to http response.
+// it's a porting of the security middleware used by other microservices of the IO platform
+// reference: https://github.com/pagopa/io-functions-commons/blob/master/src/utils/express.ts
+export const withSecurityHeaders = <A, S extends HttpStatusCode>(
+  r: HttpResponse<A, S>
+): HttpResponse<A, S> => ({
+  ...r,
+  headers: {
+    "Content-Security-Policy": "default-src 'none'; upgrade-insecure-requests",
+    "Cross-Origin-Embedder-Policy": "require-corp",
+    "Cross-Origin-Opener-Policy": "same-origin",
+    "Cross-Origin-Resource-Policy": "same-origin",
+    "Origin-Agent-Cluster": "?1",
+    "Referrer-Policy": "no-referrer",
+    "Strict-Transport-Security": "max-age=15552000; includeSubDomains",
+    "X-Content-Type-Options": "nosniff",
+    "X-DNS-Prefetch-Control": "off",
+    "X-Download-Options": "noopen",
+    "X-Frame-Options": "DENY",
+    "X-Permitted-Cross-Domain-Policies": "none",
+    "X-XSS-Protection": "0",
+    ...r.headers,
+  },
+});
+
+export const empty: HttpResponse<null, 204> = withSecurityHeaders({
+  statusCode: 204,
+  body: null,
+  headers: {},
+});
+
+export const success = <A>(body: A): HttpResponse<A, 200> =>
+  withSecurityHeaders({
+    statusCode: 200,
+    headers: {},
+    body,
+  });
+
+export const successJson = flow(
+  success,
+  withHeader("Content-Type", "application/json")
+);
+
+export const createdJson = flow(successJson, withStatusCode(201));
+
+export type ProblemJson = {
+  type?: string;
+  title: string;
+  status: HttpErrorStatusCode;
+  detail?: string;
+  [extra: string]: unknown;
+};
+
+export const problemJson = (
+  problem: ProblemJson
+): HttpResponse<ProblemJson, HttpErrorStatusCode> =>
+  withSecurityHeaders({
+    statusCode: problem.status,
+    body: problem,
+    headers: {
+      "Content-Type": "application/problem+json",
+    },
+  });

--- a/packages/handler-kit/src/index.ts
+++ b/packages/handler-kit/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./http";
+export * from "./handler";
+export * from "./validation";

--- a/packages/handler-kit/src/validation.ts
+++ b/packages/handler-kit/src/validation.ts
@@ -1,0 +1,23 @@
+import * as E from "fp-ts/lib/Either";
+import { flow } from "fp-ts/function";
+
+import { failure } from "io-ts/PathReporter";
+import { Decoder } from "io-ts";
+
+export class ValidationError extends Error {
+  static defaultMessage = "Your request parameters didn't validate";
+  name = "ValidationError";
+  violations: string[];
+  constructor(violations: string[], message = ValidationError.defaultMessage) {
+    super(message);
+    this.violations = violations;
+  }
+}
+
+const toValidationError = (message: string) =>
+  flow(failure, (violations) => new ValidationError(violations, message));
+
+export const parse = <T>(
+  schema: Decoder<unknown, T>,
+  message = ValidationError.defaultMessage
+) => flow(schema.decode, E.mapLeft(toValidationError(message)));

--- a/packages/handler-kit/tsconfig.json
+++ b/packages/handler-kit/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src"
+  }
+}

--- a/packages/handler-kit/tsup.config.js
+++ b/packages/handler-kit/tsup.config.js
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["./src/index.ts"],
+  splitting: false,
+  sourcemap: true,
+  dts: true,
+  clean: true,
+  target: "node18",
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -5,6 +5,17 @@ __metadata:
   version: 6
   cacheKey: 8
 
+"@azure/functions@npm:^3.5.0":
+  version: 3.5.0
+  resolution: "@azure/functions@npm:3.5.0"
+  dependencies:
+    iconv-lite: ^0.6.3
+    long: ^4.0.0
+    uuid: ^8.3.0
+  checksum: 105ddb7378d4b21e769de3d998b9e88913782356ac0edca20e1c0dbd1ac7fb15f6ca04f86121ce1ed5b2ec49564b64788d2046bf6e71f0199555e37c88cfaf8d
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0":
   version: 7.18.6
   resolution: "@babel/code-frame@npm:7.18.6"
@@ -803,7 +814,45 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/logger@workspace:packages/logger":
+"@pagopa/handler-kit-azure-func@workspace:packages/handler-kit-azure-func":
+  version: 0.0.0-use.local
+  resolution: "@pagopa/handler-kit-azure-func@workspace:packages/handler-kit-azure-func"
+  dependencies:
+    "@azure/functions": ^3.5.0
+    "@pagopa/eslint-config": ^3.0.0
+    "@pagopa/handler-kit": ^0.9.0
+    "@pagopa/logger": ^1.0.0
+    "@rushstack/eslint-patch": ^1.2.0
+    "@vitest/coverage-c8": ^0.29.2
+    eslint: ^8.36.0
+    fp-ts: ^2.13.1
+    io-ts: ^2.2.20
+    prettier: 2.8.4
+    tsup: ^6.6.3
+    typescript: ^5.0.2
+    vitest: ^0.29.2
+  languageName: unknown
+  linkType: soft
+
+"@pagopa/handler-kit@^0.9.0, @pagopa/handler-kit@workspace:packages/handler-kit":
+  version: 0.0.0-use.local
+  resolution: "@pagopa/handler-kit@workspace:packages/handler-kit"
+  dependencies:
+    "@pagopa/eslint-config": ^3.0.0
+    "@pagopa/logger": ^1.0.0
+    "@rushstack/eslint-patch": ^1.2.0
+    "@vitest/coverage-c8": ^0.29.2
+    eslint: ^8.36.0
+    fp-ts: ^2.13.1
+    io-ts: ^2.2.20
+    prettier: 2.8.4
+    tsup: ^6.6.3
+    typescript: ^5.0.2
+    vitest: ^0.29.2
+  languageName: unknown
+  linkType: soft
+
+"@pagopa/logger@^1.0.0, @pagopa/logger@workspace:packages/logger":
   version: 0.0.0-use.local
   resolution: "@pagopa/logger@workspace:packages/logger"
   dependencies:
@@ -3196,7 +3245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"iconv-lite@npm:^0.6.2":
+"iconv-lite@npm:^0.6.2, iconv-lite@npm:^0.6.3":
   version: 0.6.3
   resolution: "iconv-lite@npm:0.6.3"
   dependencies:
@@ -3280,6 +3329,15 @@ __metadata:
     turbo: ^1.8.5
   languageName: unknown
   linkType: soft
+
+"io-ts@npm:^2.2.20":
+  version: 2.2.20
+  resolution: "io-ts@npm:2.2.20"
+  peerDependencies:
+    fp-ts: ^2.5.0
+  checksum: 72517bf72ab1ad61b81960cb37f46e7a9f6dc84235b7d9b62f346ca84120dd89134b652fc3a0b9751129331084fd3e059349561bb96587d91ba7b40985fe7aac
+  languageName: node
+  linkType: hard
 
 "ip@npm:^2.0.0":
   version: 2.0.0
@@ -3794,6 +3852,13 @@ __metadata:
   version: 4.17.21
   resolution: "lodash@npm:4.17.21"
   checksum: eb835a2e51d381e561e508ce932ea50a8e5a68f4ebdd771ea240d3048244a8d13658acbd502cd4829768c56f2e16bdd4340b9ea141297d472517b83868e677f7
+  languageName: node
+  linkType: hard
+
+"long@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "long@npm:4.0.0"
+  checksum: 16afbe8f749c7c849db1f4de4e2e6a31ac6e617cead3bdc4f9605cb703cd20e1e9fc1a7baba674ffcca57d660a6e5b53a9e236d7b25a295d3855cca79cc06744
   languageName: node
   linkType: hard
 
@@ -5790,6 +5855,15 @@ __metadata:
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 474acf1146cb2701fe3b074892217553dfcf9a031280919ba1b8d651a068c9b15d863b7303cb15bd00a862b498e6cf4ad7b4a08fb134edd5a6f7641681cb54a2
+  languageName: node
+  linkType: hard
+
+"uuid@npm:^8.3.0":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,7 +803,25 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pagopa/logger@workspace:packages/logger":
+"@pagopa/handler-kit@workspace:packages/handler-kit":
+  version: 0.0.0-use.local
+  resolution: "@pagopa/handler-kit@workspace:packages/handler-kit"
+  dependencies:
+    "@pagopa/eslint-config": ^3.0.0
+    "@pagopa/logger": ^1.0.0
+    "@rushstack/eslint-patch": ^1.2.0
+    "@vitest/coverage-c8": ^0.29.2
+    eslint: ^8.36.0
+    fp-ts: ^2.13.1
+    io-ts: ^2.2.20
+    prettier: 2.8.4
+    tsup: ^6.6.3
+    typescript: ^5.0.2
+    vitest: ^0.29.2
+  languageName: unknown
+  linkType: soft
+
+"@pagopa/logger@^1.0.0, @pagopa/logger@workspace:packages/logger":
   version: 0.0.0-use.local
   resolution: "@pagopa/logger@workspace:packages/logger"
   dependencies:
@@ -3280,6 +3298,15 @@ __metadata:
     turbo: ^1.8.5
   languageName: unknown
   linkType: soft
+
+"io-ts@npm:^2.2.20":
+  version: 2.2.20
+  resolution: "io-ts@npm:2.2.20"
+  peerDependencies:
+    fp-ts: ^2.5.0
+  checksum: 72517bf72ab1ad61b81960cb37f46e7a9f6dc84235b7d9b62f346ca84120dd89134b652fc3a0b9751129331084fd3e059349561bb96587d91ba7b40985fe7aac
+  languageName: node
+  linkType: hard
 
 "ip@npm:^2.0.0":
   version: 2.0.0


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Port `@pagopa/handler-kit` from https://github.com/pagopa/handler-kit
2. Rewrite it to support `Reader` from `fp-ts` and a more simpler API

<!--- Describe your changes in detail -->

#### Motivation and Context

Now `fp-ts` is based on `ReaderTaskEither` instead of `TaskEither`. This allows us to write more composable handlers that are REALLY agnostic

<!--- Why is this change required? What problem does it solve? -->

#### How Has This Been Tested?

The project is fully unit tested

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
