### PR TITLE
ci: pin actions to a full length commit SHA instead of tag

### DIFF
--- a/.github/workflows/code-review.yaml
+++ b/.github/workflows/code-review.yaml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3 (3.5.0)
         with:
           fetch-depth: 2
 
       - name: Cache turbo build setup
-        uses: actions/cache@v3
+        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3 (3.3.1)
         with:
           path: .turbo
           key: ${{ runner.os }}-turbo-${{ github.sha }}
@@ -34,7 +34,7 @@ jobs:
             ${{ runner.os }}-turbo-
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3 (3.6.0)
         with:
           node-version: 18
           cache: "yarn"
@@ -52,4 +52,4 @@ jobs:
         run: yarn coverage
 
       - name: "Upload to codecov.io"
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70 # v3 (3.1.1)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@8f4b7f84864484a7bf31766abe9204da3cbe65b3 # v3 (3.5.0)
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3 (3.6.0)
         with:
           node-version: 18
           cache: "yarn"
@@ -26,7 +26,7 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@e9cc34b540dd3ad1b030c57fd97269e8f6ad905a
+        uses: changesets/action@e9cc34b540dd3ad1b030c57fd97269e8f6ad905a # v1 (1.4.1)
         with:
           version: yarn version
           publish: yarn release


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Replace versions with SHA hash

<!--- Describe your changes in detail -->

#### Motivation and Context

This change is required to protect us from supply chain attacks, as described here https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

<!--- Why is this change required? What problem does it solve? -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
