### PR TITLE
fix(azure-func)!: azureFunction (async jobs) now throws on error result

### DIFF
--- a/.changeset/late-nails-arrive.md
+++ b/.changeset/late-nails-arrive.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/handler-kit-azure-func": minor
+---
+
+azureFunction now throws on error, in order to be compatible with retry mechanism of Azure

--- a/packages/handler-kit-azure-func/src/function.ts
+++ b/packages/handler-kit-azure-func/src/function.ts
@@ -43,8 +43,14 @@ export const azureFunction =
   (
     deps: Omit<R, "logger"> & { inputDecoder: t.Decoder<unknown, I> }
   ): azure.AzureFunction =>
-  (ctx) =>
-    pipe(ctx, azureFunctionTE(h, deps), TE.toUnion)();
+  (ctx) => {
+    const result = pipe(ctx, azureFunctionTE(h, deps), TE.toUnion)();
+    // we have to throws here to ensure that "retry" mechanism of Azure
+    // can be executed
+    if (result instanceof Error) {
+      throw result;
+    }
+  };
 
 const HttpRequestC = new t.Type<
   H.HttpRequest,

--- a/packages/handler-kit-azure-func/src/function.ts
+++ b/packages/handler-kit-azure-func/src/function.ts
@@ -50,6 +50,7 @@ export const azureFunction =
     if (result instanceof Error) {
       throw result;
     }
+    return result;
   };
 
 const HttpRequestC = new t.Type<


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Motivation and Context

Without throwing the aysnc jobs will be always executed "with success" and the retry mechanisms will not be triggered
