### PR TITLE
fix(azure-func): Returns binding metadata on blobTrigger

### DIFF
--- a/.changeset/smart-eagles-cross.md
+++ b/.changeset/smart-eagles-cross.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/handler-kit-azure-func": patch
+---
+
+Now functions triggered by blobTrigger returns their metadata instead of the wrong payload

--- a/packages/handler-kit-azure-func/src/trigger.ts
+++ b/packages/handler-kit-azure-func/src/trigger.ts
@@ -1,6 +1,6 @@
 import * as t from "io-ts";
 
-import { flow, pipe, identity } from "fp-ts/function";
+import { flow, pipe } from "fp-ts/function";
 
 import { lookup } from "fp-ts/Record";
 
@@ -45,18 +45,14 @@ export class BindingNotFoundError extends Error {
 }
 
 const getBindings = (t: FunctionTrigger) => (ctx: azure.Context) => {
-  switch (t.type) {
-    case "blobTrigger":
-      return E.right(ctx.bindingData);
-    default:
-      return pipe(
-        ctx.bindings,
-        lookup(t.name),
-        E.fromOption(
-          (): Error => new BindingNotFoundError(t.name, ctx.bindings)
-        )
-      );
+  if (t.type === "blobTrigger") {
+    return E.right(ctx.bindingData);
   }
+  return pipe(
+    ctx.bindings,
+    lookup(t.name),
+    E.fromOption((): Error => new BindingNotFoundError(t.name, ctx.bindings))
+  );
 };
 
 export const getTriggerBindingData = flow(


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

The adapter returned the wrong payload as input to `handler-kit`. In the case of the `blobTrigger`, the payload to consider is `bindingMetadata`
