### PR TITLE
feat: add `package` as supported workspace type

### DIFF
--- a/make-workspace-artifact/README.md
+++ b/make-workspace-artifact/README.md
@@ -13,6 +13,10 @@ Create a workflow `.yml` file in your repository's `.github/workflows` directory
 ### Inputs
 
 - `workspace-name` the name of the workspace. must match the name of the folder containing it (`/apps/{workspace-name}`)
+- `workspace-type` (optional )the type of the workspace, indicating the kind of artifact to build. If not provided, the action will try to infer it from the workspace's content. Supported types:
+  - `function-app` Azure Function App
+  - `next-standalone` Standalone Next.js application
+  - `package` a package to be published to NPM or compatible registry
 
 ### Outputs
 
@@ -44,6 +48,8 @@ jobs:
         with:
           # it lives in /apps/my-workspace
           workspace-name: my-workspace
+          # optional
+          workspace-type: package
 
       - uses: actions/upload-artifact@v3
         with:

--- a/make-workspace-artifact/action.yml
+++ b/make-workspace-artifact/action.yml
@@ -1,18 +1,30 @@
 name: "Make workspace artifact"
+description: "This action creates an artifact for the selected workspace."
 
 inputs:
   workspace-name:
+    description: The name of the workspace to create the artifact for"
     required: true
+  workspace-type:
+    description: |
+      The type of the workspace to create the artifact for.
+      Will be inferred if not provided.
+      The supported workspace types are: function-app, next-standalone, package
+    required: false
 outputs:
   artifact-path:
+    description: The path to the created artifact
     value: ${{ steps[format('make-{0}-artifact', steps.detect-workspace-type.outputs.workspace-type)].outputs.artifact-path }}
 runs:
   using: "composite"
   steps:
-    - name: Detect workspace type
-      id: detect-workspace-type
+    # If not provided, try to detect the type of the workspace from its content.
+    - name: Set workspace type
+      id: set-workspace-type
       run: |
-        if [ -e "host.json" ]; then
+        if [[-n "${{ inputs.workspace-type }}" ]]; then
+          echo "workspace-type=${{ inputs.workspace-type }}" >> "$GITHUB_OUTPUT"
+        elif [ -e "host.json" ]; then
           echo "::debug:: the workspace contains an azure function app"
           echo "workspace-type=function-app" >> "$GITHUB_OUTPUT"
         elif [ -e "next.config.js" ] && grep -q 'output: "standalone"' "next.config.js"; then
@@ -44,5 +56,17 @@ runs:
         npm pkg set --json "files"='["**/function.json", "dist", "host.json","extensions.csproj"]'
         npx npm-pack-zip
         echo "artifact-path=$(realpath ${{ inputs.workspace-name }}.zip)" >> "$GITHUB_OUTPUT"
+      shell: bash
+      working-directory: ./out/apps/${{ inputs.workspace-name }}
+
+    - name: Make the package artifact
+      if: ${{ steps.detect-workspace-type.outputs.workspace-type == 'package' }}
+      id: make-package-artifact
+      run: |
+        # Bundle a package tarball for the selected workspace.
+        # The tarball will be created in the root of the workspace.
+        # The filename already contains the extension .
+        filename=$(npm pack --workspace ${{ inputs.workspace-name }} | jq -r '.[0].filename')
+        echo "artifact-path=$(realpath $filename)" >> "$GITHUB_OUTPUT"
       shell: bash
       working-directory: ./out/apps/${{ inputs.workspace-name }}


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* add `package` as supported workspace type
* implement package artifact bundling
* set `workspace-type` as optional argument for the `make-workspace-artifact` action

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
To support the publication of packages to NPM or alternative registries. A workspace labeled as `package` will result in a tarball ready to be fed to `npm publish` command.

As a chore, an optional `workspace-type` input is added. If not specified, it will try to detect the type from the workspace content (just like it does so far)

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
