### PR TITLE
feat: Use same version of `turbo`

### DIFF
--- a/build-workspace/action.yml
+++ b/build-workspace/action.yml
@@ -8,7 +8,10 @@ runs:
   using: "composite"
   steps:
     - name: Prune monorepo targeting ${{ inputs.workspace-name }}
-      run: npx turbo@1.9.3 prune --scope ${{ inputs.workspace-name }}
+      run: |
+        turbo_version=$(echo `node -p "require('./package.json').devDependencies.turbo"`) 
+        echo "::debug:: using turbo@$turbo_version"
+        npx turbo@$turbo_version prune --scope ${{ inputs.workspace-name }}
       shell: bash
 
     - name: Setup Node.js

--- a/build-workspace/action.yml
+++ b/build-workspace/action.yml
@@ -9,7 +9,7 @@ runs:
   steps:
     - name: Prune monorepo targeting ${{ inputs.workspace-name }}
       run: |
-        turbo_version=$(echo `node -p "require('./package.json').devDependencies.turbo"`) 
+        turbo_version=$(yarn info turbo --json | jq -r '.children.Version')
         echo "::debug:: using turbo@$turbo_version"
         npx turbo@$turbo_version prune --scope ${{ inputs.workspace-name }}
       shell: bash


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

<!--- Describe your changes in detail -->
* read `turbo` version from package.json

#### Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
We use `turbo prune` feature to efficiently package the workspaces independently. As we download the package _on-the-fly_ using `npx`, it's safer to pin the version to the actual one used by the monorepo itself

#### How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
