### PR TITLE
fix(handler-kit-azure-func): Now Http Request is parsed correctly

### DIFF
--- a/.changeset/clean-walls-march.md
+++ b/.changeset/clean-walls-march.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/handler-kit-azure-func": patch
+---
+
+Now HttpRequest from @azure/functions@4 is parsed correctly


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes
1. `httpAzureFunction` now parse differently the given `HttpRequest` object 

<!--- Describe your changes in detail -->

#### Motivation and Context
Since `@azure/functions@4` the `HttpRequest` is aligned to the standard fetch `Request` object, is not longer a plain JS object. 

<!--- Why is this change required? What problem does it solve? -->
