### PR TITLE
Fix: handler-kit-azure-func does not throw errors

### DIFF
--- a/.changeset/silver-llamas-do.md
+++ b/.changeset/silver-llamas-do.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/handler-kit-azure-func": patch
+---
+
+await for handler result in order to throws on error

--- a/packages/handler-kit-azure-func/src/function.ts
+++ b/packages/handler-kit-azure-func/src/function.ts
@@ -43,8 +43,11 @@ export const azureFunction =
   (
     deps: Omit<R, "logger" | "input"> & { inputDecoder: t.Decoder<unknown, I> }
   ) =>
-  (input: unknown, ctx: InvocationContext) => {
-    const result = pipe(azureFunctionTE(h, deps)(input, ctx), TE.toUnion)();
+  async (input: unknown, ctx: InvocationContext) => {
+    const result = await pipe(
+      azureFunctionTE(h, deps)(input, ctx),
+      TE.toUnion
+    )();
     // we have to throws here to ensure that "retry" mechanism of Azure
     // can be executed
     if (result instanceof Error) {


### PR DESCRIPTION
#### List of Changes
1. add `await` to get `result` value and throws in case of errors
<!--- Describe your changes in detail -->

#### Motivation and Context
Without this change `result` can't evaluated and the retry mechanism of Azure Function does not work (this bug was already fixed in `1.x` branch, for the old programming model)

