### PR TITLE
fix: updated httpAzureFunction function

### DIFF
--- a/.changeset/nice-books-kneel.md
+++ b/.changeset/nice-books-kneel.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/handler-kit-azure-func": patch
+---
+
+Fixed body response type

--- a/packages/handler-kit-azure-func/src/__test__/function.spec.ts
+++ b/packages/handler-kit-azure-func/src/__test__/function.spec.ts
@@ -69,11 +69,63 @@ describe("httpAzureFunction", () => {
       ctx
     );
     expect(CtxErrorSpy).toHaveBeenCalled();
-    expect(response.json()).resolves.toEqual(
+    await expect(response.json()).resolves.toEqual(
       expect.objectContaining({
         status: 500,
       })
     );
+  });
+
+  it("it should return 200 and a string body when the handler returns a response with Content-Type equal to application/entity-statement+jwt and a string body", async () => {
+    const handler = H.of(() =>
+      pipe(
+        RTE.of("jwt"),
+        RTE.map(
+          flow(
+            H.success,
+            H.withHeader("Content-Type", "application/entity-statement+jwt")
+          )
+        ),
+        RTE.orElseW(flow(H.toProblemJson, H.problemJson, RTE.right))
+      )
+    );
+    const message = new HttpRequest({
+      url: "https://my-request.pagopa.it",
+      method: "GET",
+    });
+    const response = await httpAzureFunction(handler)({})(message, ctx);
+
+    expect(response.status).toEqual(200);
+    expect(response.headers.get("content-type")).toEqual(
+      "application/entity-statement+jwt"
+    );
+    await expect(response.text()).resolves.toEqual("jwt");
+  });
+
+  it("it should return 500 when the handler returns a response with Content-Type equal to application/entity-statement+jwt but an object body", async () => {
+    const handler = H.of(() =>
+      pipe(
+        RTE.of({ jwt: "jwt" }),
+        RTE.map(
+          flow(
+            H.success,
+            H.withHeader("Content-Type", "application/entity-statement+jwt")
+          )
+        ),
+        RTE.orElseW(flow(H.toProblemJson, H.problemJson, RTE.right))
+      )
+    );
+    const message = new HttpRequest({
+      url: "https://my-request.pagopa.it",
+      method: "GET",
+    });
+    const response = await httpAzureFunction(handler)({})(message, ctx);
+
+    expect(response.status).toEqual(500);
+    expect(response.headers.get("content-type")).toEqual(
+      "application/problem+json"
+    );
+    await expect(response.text()).resolves.toEqual("Internal server error");
   });
 });
 


### PR DESCRIPTION
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->

#### List of Changes

1. Updated `toAzureHttpResponse` function in the `handler-kit-azure-func` package
2. Added unit tests

#### Motivation and Context

Until now, the function returning the Azure response has always used `jsonBody`, which is a JSON-serializable HTTP Response body. Then, it did not work properly when it needed to return a string type body.


#### How Has This Been Tested?

Manually and with unit tests

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

#### Screenshots (if appropriate):

<!--- Attach screenshots in case changes impact UI. -->

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
