### PR TITLE
fix: Fix 204 NoContent response and remove application/entity-statement+jwt

### DIFF
--- a/.changeset/sweet-bears-hang.md
+++ b/.changeset/sweet-bears-hang.md
@@ -1,0 +1,5 @@
+---
+"@pagopa/handler-kit-azure-func": patch
+---
+
+Fixed 204 NoContent response

--- a/packages/handler-kit-azure-func/package.json
+++ b/packages/handler-kit-azure-func/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pagopa/handler-kit-azure-func",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "homepage": "https://github.com/pagopa/io-std#readme",
   "bugs": {
     "url": "https://github.com/pagopa/io-std/issues"

--- a/packages/handler-kit-azure-func/src/__test__/function.spec.ts
+++ b/packages/handler-kit-azure-func/src/__test__/function.spec.ts
@@ -75,58 +75,6 @@ describe("httpAzureFunction", () => {
       })
     );
   });
-
-  it("it should return 200 and a string body when the handler returns a response with Content-Type equal to application/entity-statement+jwt and a string body", async () => {
-    const handler = H.of(() =>
-      pipe(
-        RTE.of("jwt"),
-        RTE.map(
-          flow(
-            H.success,
-            H.withHeader("Content-Type", "application/entity-statement+jwt")
-          )
-        ),
-        RTE.orElseW(flow(H.toProblemJson, H.problemJson, RTE.right))
-      )
-    );
-    const message = new HttpRequest({
-      url: "https://my-request.pagopa.it",
-      method: "GET",
-    });
-    const response = await httpAzureFunction(handler)({})(message, ctx);
-
-    expect(response.status).toEqual(200);
-    expect(response.headers.get("content-type")).toEqual(
-      "application/entity-statement+jwt"
-    );
-    await expect(response.text()).resolves.toEqual("jwt");
-  });
-
-  it("it should return 500 when the handler returns a response with Content-Type equal to application/entity-statement+jwt but an object body", async () => {
-    const handler = H.of(() =>
-      pipe(
-        RTE.of({ jwt: "jwt" }),
-        RTE.map(
-          flow(
-            H.success,
-            H.withHeader("Content-Type", "application/entity-statement+jwt")
-          )
-        ),
-        RTE.orElseW(flow(H.toProblemJson, H.problemJson, RTE.right))
-      )
-    );
-    const message = new HttpRequest({
-      url: "https://my-request.pagopa.it",
-      method: "GET",
-    });
-    const response = await httpAzureFunction(handler)({})(message, ctx);
-
-    expect(response.status).toEqual(500);
-    expect(response.headers.get("content-type")).toEqual(
-      "application/problem+json"
-    );
-    await expect(response.text()).resolves.toEqual("Internal server error");
-  });
 });
 
 describe("azureFunction", () => {

--- a/packages/handler-kit-azure-func/src/__test__/function.spec.ts
+++ b/packages/handler-kit-azure-func/src/__test__/function.spec.ts
@@ -115,6 +115,23 @@ describe("httpAzureFunction", () => {
     );
     await expect(response.text()).resolves.toEqual("Internal server error");
   });
+
+  it("it should return 204 and an empty body when the handler returns a response with NoContent body", async () => {
+    const handler = H.of(() =>
+      pipe(
+        RTE.of(H.empty),
+        RTE.orElseW(flow(H.toProblemJson, H.problemJson, RTE.right))
+      )
+    );
+    const message = new HttpRequest({
+      url: "https://my-request.pagopa.it",
+      method: "GET",
+    });
+    const response = await httpAzureFunction(handler)({})(message, ctx);
+
+    expect(response.status).toEqual(204);
+    expect(response.body).toBe(null);
+  });
 });
 
 describe("azureFunction", () => {

--- a/packages/handler-kit-azure-func/src/function.ts
+++ b/packages/handler-kit-azure-func/src/function.ts
@@ -112,19 +112,11 @@ const toAzureHttpResponse: ({
     });
   }
   // In other cases, we use the 'body' property
-  return typeof body === "string"
-    ? new HttpResponse({
-        status: statusCode,
-        body,
-        headers,
-      })
-    : new HttpResponse({
-        status: 500,
-        body: "Internal server error",
-        headers: {
-          "Content-Type": "application/problem+json",
-        },
-      });
+  return new HttpResponse({
+    status: statusCode,
+    body: body as undefined,
+    headers,
+  });
 };
 
 // Prevent HTTP triggered Azure Functions from crashing

--- a/packages/handler-kit-azure-func/src/function.ts
+++ b/packages/handler-kit-azure-func/src/function.ts
@@ -81,7 +81,7 @@ const AzureHttpRequestC = t.type({
   params: t.record(t.string, t.string),
   query: t.record(t.string, t.string),
   headers: t.record(t.string, t.string),
-  body: t.unknown,
+  body: t.any,
 });
 
 type AzureHttpRequest = t.TypeOf<typeof AzureHttpRequestC>;
@@ -111,11 +111,22 @@ const toAzureHttpResponse: ({
       headers,
     });
   }
+
   // In other cases, we use the 'body' property
+  if (typeof body === "string" || body === null) {
+    return new HttpResponse({
+      status: statusCode,
+      body,
+      headers,
+    });
+  }
+
   return new HttpResponse({
-    status: statusCode,
-    body: body as undefined,
-    headers,
+    status: 500,
+    body: "Internal server error. Body is not a string, object or null.",
+    headers: {
+      "Content-Type": "application/problem+json",
+    },
   });
 };
 

--- a/packages/handler-kit-azure-func/src/function.ts
+++ b/packages/handler-kit-azure-func/src/function.ts
@@ -123,7 +123,7 @@ const toAzureHttpResponse: ({
 
   return new HttpResponse({
     status: 500,
-    body: "Internal server error. Body is not a string, object or null.",
+    body: "Internal server error",
     headers: {
       "Content-Type": "application/problem+json",
     },

--- a/packages/handler-kit-azure-func/src/function.ts
+++ b/packages/handler-kit-azure-func/src/function.ts
@@ -81,7 +81,7 @@ const AzureHttpRequestC = t.type({
   params: t.record(t.string, t.string),
   query: t.record(t.string, t.string),
   headers: t.record(t.string, t.string),
-  body: t.any,
+  body: t.unknown,
 });
 
 type AzureHttpRequest = t.TypeOf<typeof AzureHttpRequestC>;


### PR DESCRIPTION
If the `H.empty` response of handler-kit is used which expects a `null` body,
https://github.com/pagopa/io-std/blob/008f872d2e6d3288f0dc88934f0d986c1eb519ac/packages/handler-kit/src/http/response.ts#L93
the `handler-kit-azure-func` always returns a 500 Internal Server Error since body is not a string. 

This PR eliminates body type control with a cast to undefined.

Furthermore, the` application/entity-statement+jwt` content-type test is also eliminated as it is not regulated by IANA but to date only mentioned in an IETF draft.

